### PR TITLE
Tokenization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/17 10:49:54 by lrocigno          #+#    #+#              #
-#    Updated: 2022/01/28 23:50:30 by lrocigno         ###   ########.fr        #
+#    Updated: 2022/02/02 01:12:26 by lrocigno         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -52,9 +52,10 @@ LIBS = $(LIBFT_FLAGS) -lreadline
 INCLUDES = -I ./lib/libft/includes \
 		   -I ./src
 
-vpath %.c src src/env src/prompt
+vpath %.c src src/env src/prompt src/lexer
 SRC := minishell.c get_pwd.c prompt.c interface.c free.c \
-	   error.c parse.c get_env.c set_env.c
+	   error.c parse.c get_env.c set_env.c \
+	   get_type.c get_value.c helpers.c tokenizer.c token_new_del.c \
 
 OBJ_PATH = ./build
 OBJ := $(addprefix $(OBJ_PATH)/,$(SRC:%.c=%.o))

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/17 10:49:54 by lrocigno          #+#    #+#              #
-#    Updated: 2022/02/02 01:12:26 by lrocigno         ###   ########.fr        #
+#    Updated: 2022/02/02 14:24:27 by lrocigno         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -55,7 +55,7 @@ INCLUDES = -I ./lib/libft/includes \
 vpath %.c src src/env src/prompt src/lexer
 SRC := minishell.c get_pwd.c prompt.c interface.c free.c \
 	   error.c parse.c get_env.c set_env.c \
-	   get_type.c get_value.c helpers.c tokenizer.c token_new_del.c \
+	   get_type.c get_value.c helpers.c quote.c tokenizer.c token_new_del.c \
 
 OBJ_PATH = ./build
 OBJ := $(addprefix $(OBJ_PATH)/,$(SRC:%.c=%.o))

--- a/src/interface.c
+++ b/src/interface.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/27 20:12:16 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/01/31 14:26:21 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/01 23:03:20 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 
 static char	validate(char *input)
 {
-	if (input == NULL)
+	if (input == NULL || ft_strlen(input) == 0)
 		return (0);
 	if (ft_strncmp("exit", input, ft_strlen(input)) == 0)
 		return (1);

--- a/src/interface.c
+++ b/src/interface.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/27 20:12:16 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/02/01 23:03:20 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 15:06:12 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,8 @@ static char	validate(char *input)
 
 void	interface(char *input, t_shell *sh)
 {
+	t_token	**tokens;
+
 	input = prompt(sh);
 	if (validate(input))
 	{
@@ -32,6 +34,8 @@ void	interface(char *input, t_shell *sh)
 		free_sh(sh);
 		exit(EXIT_SUCCESS);
 	}
+	tokens = tokenizer(input);
+	discard_tokens(tokens);
 	safe_free((void **)&input);
 	interface(input, sh);
 }

--- a/src/lexer/get_type.c
+++ b/src/lexer/get_type.c
@@ -6,11 +6,32 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/02 00:28:34 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 01:17:23 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 13:25:17 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <lexer/lexer.h>
+
+/**
+ * Test if the token is a built-in
+ */
+
+static int	isbuiltin(char *input)
+{
+	if (ft_strlen(input) == 0)
+		return (0);
+	if (ft_strncmp("echo ", input, 5) == 0
+		|| ft_strncmp("cd ", input, 3) == 0
+		|| ft_strncmp("pwd ", input, 4) == 0
+		|| ft_strncmp("export ", input, 7) == 0
+		|| ft_strncmp("unset ", input, 6) == 0
+		|| ft_strncmp("env ", input, 4) == 0
+		|| ft_strncmp("exit ", input, 5) == 0)
+	{
+		return (1);
+	}
+	return (0);
+}
 
 /**
  * Search for a white space between quotes (the first spoted before the call for
@@ -20,13 +41,13 @@
 static int	isstrlit(char *input)
 {
 	int		presume;
-	char	qot_t;
 
 	presume = 0;
-	qot_t = '\0';
 	if (*input == '\"' || *input == '\'')
-		qot_t = *input;
-	while (*input != '\0' && *input != qot_t)
+		set_quote(*input);
+	else
+		return (presume);
+	while (*input != '\0' && *input != get_quote())
 	{
 		if (lex_isspace(*input))
 			presume = 1;
@@ -39,13 +60,18 @@ static int	isstrlit(char *input)
 
 t_type	get_type(size_t i, char *input)
 {
+	char	q;
+
+	q = *input;
 	while (lex_isspace(*input))
 		++input;
 	if (isstrlit(input))
 		return (STRING_LITERAL);
 	else if (isstrlit(input) == -1)
 		return (INVALID);
-	else if (lex_isbuiltin(input))
+	while (*input == q && (q == '\"' || q == '\''))
+		++input;
+	if (isbuiltin(input))
 		return (BUILTIN);
 	else if (ft_isdigit(*input))
 		return (INT_LITERAL);

--- a/src/lexer/get_type.c
+++ b/src/lexer/get_type.c
@@ -6,7 +6,7 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/02 00:28:34 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 13:25:17 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 20:34:31 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,10 +44,12 @@ static int	isstrlit(char *input)
 
 	presume = 0;
 	if (*input == '\"' || *input == '\'')
-		set_quote(*input);
+		quote(*input);
 	else
 		return (presume);
-	while (*input != '\0' && *input != get_quote())
+	while (*input == quote('g'))
+		++input;
+	while (*input != '\0' && *input != quote('g'))
 	{
 		if (lex_isspace(*input))
 			presume = 1;
@@ -73,13 +75,11 @@ t_type	get_type(size_t i, char *input)
 		++input;
 	if (isbuiltin(input))
 		return (BUILTIN);
+	else if (ft_isalnum(*input) && i == 0)
+		return (COMMAND);
 	else if (ft_isdigit(*input))
 		return (INT_LITERAL);
-	else if (ft_isalpha(*input) && i == 0)
-		return (COMMAND);
 	else if (*input == '-' || ft_isalpha(*input))
 		return (PARAMETER);
-	else if (*input == '#')
-		return (COMMENT);
 	return (INVALID);
 }

--- a/src/lexer/get_type.c
+++ b/src/lexer/get_type.c
@@ -1,0 +1,59 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   get_type.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/02 00:28:34 by lrocigno          #+#    #+#             */
+/*   Updated: 2022/02/02 01:17:23 by lrocigno         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <lexer/lexer.h>
+
+/**
+ * Search for a white space between quotes (the first spoted before the call for
+ * this function and another one present in input).
+ */
+
+static int	isstrlit(char *input)
+{
+	int		presume;
+	char	qot_t;
+
+	presume = 0;
+	qot_t = '\0';
+	if (*input == '\"' || *input == '\'')
+		qot_t = *input;
+	while (*input != '\0' && *input != qot_t)
+	{
+		if (lex_isspace(*input))
+			presume = 1;
+		++input;
+	}
+	if (*input == '\0')
+		presume = -1;
+	return (presume);
+}
+
+t_type	get_type(size_t i, char *input)
+{
+	while (lex_isspace(*input))
+		++input;
+	if (isstrlit(input))
+		return (STRING_LITERAL);
+	else if (isstrlit(input) == -1)
+		return (INVALID);
+	else if (lex_isbuiltin(input))
+		return (BUILTIN);
+	else if (ft_isdigit(*input))
+		return (INT_LITERAL);
+	else if (ft_isalpha(*input) && i == 0)
+		return (COMMAND);
+	else if (*input == '-' || ft_isalpha(*input))
+		return (PARAMETER);
+	else if (*input == '#')
+		return (COMMENT);
+	return (INVALID);
+}

--- a/src/lexer/get_value.c
+++ b/src/lexer/get_value.c
@@ -1,0 +1,31 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   get_value.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/02 00:52:29 by lrocigno          #+#    #+#             */
+/*   Updated: 2022/02/02 01:17:47 by lrocigno         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <lexer/lexer.h>
+
+char	*get_value(t_type type, char *input)
+{
+	size_t	len;
+	char	*ret;
+
+	len = 0;
+	while (*input)
+	{
+		if (ft_isalnum(*input) || type == STRING_LITERAL)
+			++len;
+		else if (lex_isspace(*input))
+			break ;
+		++input;
+	}
+	ret = ft_calloc(len, sizeof (*ret));
+	return (ret);
+}

--- a/src/lexer/get_value.c
+++ b/src/lexer/get_value.c
@@ -6,7 +6,7 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/02 00:52:29 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 14:34:24 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 20:34:31 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,8 @@
 
 static int	isstop(char inchar, char stop)
 {
+	if (inchar == '#')
+		return (1);
 	if (stop == '\0')
 		return (lex_isspace(inchar) == 1 || inchar == stop);
 	else
@@ -40,9 +42,11 @@ static size_t	vallen(t_type type, char *input)
 
 	len = 0;
 	if (type == STRING_LITERAL)
-		stop = get_quote();
+		stop = quote('g');
 	else
 		stop = '\0';
+	while (*input == quote('g'))
+		++input;
 	while (isstop(*input, stop) == 0)
 	{
 		if (ft_isalnum(*input) || type == STRING_LITERAL)
@@ -62,19 +66,19 @@ char	*get_value(t_type type, char *input)
 		++input;
 	len = vallen(type, input);
 	i = 0;
-	ret = ft_calloc(len, sizeof (*ret));
+	ret = ft_calloc(len + 1, sizeof (*ret));
 	if (!ret)
 		return (NULL);
 	while (i < len)
 	{
 		if (ft_isalnum(*input)
-			|| (type == STRING_LITERAL && *input != get_quote()))
+			|| (type == STRING_LITERAL && *input != quote('g')))
 		{
 			ret[i] = *input;
 			++i;
 		}
 		++input;
 	}
-	ret[i] = '\0';
+	quote('d');
 	return (ret);
 }

--- a/src/lexer/get_value.c
+++ b/src/lexer/get_value.c
@@ -6,26 +6,75 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/02 00:52:29 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 01:17:47 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 14:34:24 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <lexer/lexer.h>
 
-char	*get_value(t_type type, char *input)
+/**
+ * Test if the inchar (input char) is equal stop. When stop is \0, isstop also
+ * test if inchar is a white space.
+ *
+ * Return the result of the test.
+ */
+
+static int	isstop(char inchar, char stop)
+{
+	if (stop == '\0')
+		return (lex_isspace(inchar) == 1 || inchar == stop);
+	else
+		return (inchar == stop);
+}
+
+/**
+ * Predict the size of string value.
+ *
+ * Return the predicted size of string value.
+ */
+
+static size_t	vallen(t_type type, char *input)
 {
 	size_t	len;
-	char	*ret;
+	char	stop;
 
 	len = 0;
-	while (*input)
+	if (type == STRING_LITERAL)
+		stop = get_quote();
+	else
+		stop = '\0';
+	while (isstop(*input, stop) == 0)
 	{
 		if (ft_isalnum(*input) || type == STRING_LITERAL)
 			++len;
-		else if (lex_isspace(*input))
-			break ;
 		++input;
 	}
+	return (len);
+}
+
+char	*get_value(t_type type, char *input)
+{
+	size_t	len;
+	size_t	i;
+	char	*ret;
+
+	while (lex_isspace(*input))
+		++input;
+	len = vallen(type, input);
+	i = 0;
 	ret = ft_calloc(len, sizeof (*ret));
+	if (!ret)
+		return (NULL);
+	while (i < len)
+	{
+		if (ft_isalnum(*input)
+			|| (type == STRING_LITERAL && *input != get_quote()))
+		{
+			ret[i] = *input;
+			++i;
+		}
+		++input;
+	}
+	ret[i] = '\0';
 	return (ret);
 }

--- a/src/lexer/helpers.c
+++ b/src/lexer/helpers.c
@@ -1,0 +1,47 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   helpers.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/02 00:06:32 by lrocigno          #+#    #+#             */
+/*   Updated: 2022/02/02 01:18:36 by lrocigno         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <lexer/lexer.h>
+
+/**
+ * Test if the character is a white space.
+ */
+
+int	lex_isspace(char c)
+{
+	if (c == ' ' || c == '\t' || c == '\r')
+		return (1);
+	else if (c == '\n' || c == '\v' || c == '\f')
+		return (1);
+	return (0);
+}
+
+/**
+ * Test if the token is a built-in
+ */
+
+int	lex_isbuiltin(char *input)
+{
+	if (ft_strlen(input) == 0)
+		return (0);
+	if (ft_strncmp("echo", input, 4) == 0
+		|| ft_strncmp("cd", input, 2) == 0
+		|| ft_strncmp("pwd", input, 3) == 0
+		|| ft_strncmp("export", input, 6) == 0
+		|| ft_strncmp("unset", input, 5) == 0
+		|| ft_strncmp("env", input, 3) == 0
+		|| ft_strncmp("exit", input, 4) == 0)
+	{
+		return (1);
+	}
+	return (0);
+}

--- a/src/lexer/helpers.c
+++ b/src/lexer/helpers.c
@@ -6,7 +6,7 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/02 00:06:32 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 01:18:36 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 10:05:00 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,26 +22,5 @@ int	lex_isspace(char c)
 		return (1);
 	else if (c == '\n' || c == '\v' || c == '\f')
 		return (1);
-	return (0);
-}
-
-/**
- * Test if the token is a built-in
- */
-
-int	lex_isbuiltin(char *input)
-{
-	if (ft_strlen(input) == 0)
-		return (0);
-	if (ft_strncmp("echo", input, 4) == 0
-		|| ft_strncmp("cd", input, 2) == 0
-		|| ft_strncmp("pwd", input, 3) == 0
-		|| ft_strncmp("export", input, 6) == 0
-		|| ft_strncmp("unset", input, 5) == 0
-		|| ft_strncmp("env", input, 3) == 0
-		|| ft_strncmp("exit", input, 4) == 0)
-	{
-		return (1);
-	}
 	return (0);
 }

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -6,7 +6,7 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/01 22:44:27 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 01:16:31 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 13:25:17 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,20 @@ typedef struct s_token
 }    t_token;
 
 /**
+ * Get the defined quote.
+ * @param:
+ */
+
+char	get_quote(void);
+
+/**
+ * Set the quote.
+ * @param q: the quote character
+ */
+
+void	set_quote(char q);
+
+/**
  * t_token constructor
  * @param type: which type this token is, value: the value for the token
  */
@@ -51,14 +65,7 @@ void	del_token(t_token *del);
  * @param c: the character being verified.
  */
 
-int	lex_isspace(char c);
-
-/**
- * Return if the word is a built-in command
- * @param input: the user input.
- */
-
-int	lex_isbuiltin(char *input);
+int		lex_isspace(char c);
 
 /**
  * Extract the value using the type as reference

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -6,7 +6,7 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/01 22:44:27 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 13:25:17 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 20:34:31 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,6 @@ typedef enum e_type
     PARAMETER,
     STRING_LITERAL,
     INT_LITERAL,
-	COMMENT,
 }    t_type;
 
 typedef struct s_token
@@ -33,18 +32,11 @@ typedef struct s_token
 }    t_token;
 
 /**
- * Get the defined quote.
- * @param:
+ * Set or get a quote, to set use SET_QUOTE macro, to get use GET_QUOTE instead.
+ * @param flag: one of the macros mentioned.
  */
 
-char	get_quote(void);
-
-/**
- * Set the quote.
- * @param q: the quote character
- */
-
-void	set_quote(char q);
+char	quote(char flag);
 
 /**
  * t_token constructor

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -6,7 +6,7 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/01 22:44:27 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 20:34:31 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/03 07:13:08 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,18 +18,18 @@
 typedef enum e_type
 {
 	INVALID = -1,
-    BUILTIN,
+	BUILTIN,
 	COMMAND,
-    PARAMETER,
-    STRING_LITERAL,
-    INT_LITERAL,
-}    t_type;
+	PARAMETER,
+	STRING_LITERAL,
+	INT_LITERAL,
+}	t_type;
 
 typedef struct s_token
 {
-    t_type        type;
-    const char    *value;
-}    t_token;
+	t_type		type;
+	const char	*value;
+}	t_token;
 
 /**
  * Set or get a quote, to set use SET_QUOTE macro, to get use GET_QUOTE instead.

--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -1,0 +1,91 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   lexer.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/01 22:44:27 by lrocigno          #+#    #+#             */
+/*   Updated: 2022/02/02 01:16:31 by lrocigno         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef LEXER_H
+# define LEXER_H
+
+# include <libft.h>
+
+typedef enum e_type
+{
+	INVALID = -1,
+    BUILTIN,
+	COMMAND,
+    PARAMETER,
+    STRING_LITERAL,
+    INT_LITERAL,
+	COMMENT,
+}    t_type;
+
+typedef struct s_token
+{
+    t_type        type;
+    const char    *value;
+}    t_token;
+
+/**
+ * t_token constructor
+ * @param type: which type this token is, value: the value for the token
+ */
+
+t_token	*new_token(t_type type, const char *value);
+
+/**
+ * t_token destructor
+ * @param del: the t_token object to be destroied
+ */
+
+void	del_token(t_token *del);
+
+/**
+ * Return if the character is a white space
+ * @param c: the character being verified.
+ */
+
+int	lex_isspace(char c);
+
+/**
+ * Return if the word is a built-in command
+ * @param input: the user input.
+ */
+
+int	lex_isbuiltin(char *input);
+
+/**
+ * Extract the value using the type as reference
+ * @param type: which type the token is, input: the user input
+ */
+
+char	*get_value(t_type type, char *input);
+
+/**
+ * Return the type of token it is verifying
+ * @param i: which token it is, input: the user input
+ */
+
+t_type	get_type(size_t i, char *input);
+
+/**
+ * Tokenizes the input sent by the user.
+ * @param input: the user input
+ */
+
+t_token	**tokenizer(char *input);
+
+/**
+ * Discard all the tokens.
+ * @param tokens: the array of tokens generated from tokenizer
+ */
+
+void	discard_tokens(t_token **tokens);
+
+#endif

--- a/src/lexer/quote.c
+++ b/src/lexer/quote.c
@@ -6,24 +6,19 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/02 12:44:57 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 14:41:59 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 20:31:11 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <lexer/lexer.h>
 
-char	get_quote(void)
+char	quote(char flag)
 {
 	static char	fq;
 
+	if (flag == '\"' || flag == '\'')
+		fq = flag;
+	else if (flag == 'd')
+		fq = '\0';
 	return (fq);
-}
-
-void	set_quote(char q)
-{
-	char	*fq;
-
-	fq = NULL;
-	*fq = get_quote();
-	*fq = q;
 }

--- a/src/lexer/quote.c
+++ b/src/lexer/quote.c
@@ -1,37 +1,29 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   token_new_del.c                                    :+:      :+:    :+:   */
+/*   quote.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/02/01 23:04:44 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 14:51:03 by lrocigno         ###   ########.fr       */
+/*   Created: 2022/02/02 12:44:57 by lrocigno          #+#    #+#             */
+/*   Updated: 2022/02/02 14:41:59 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <lexer/lexer.h>
 
-void	del_token(t_token *del)
+char	get_quote(void)
 {
-	char	*value;
+	static char	fq;
 
-	value = (char *)del->value;
-	free(value);
-	value = NULL;
-	del->type = INVALID;
-	free(del);
-	del = NULL;
+	return (fq);
 }
 
-t_token	*new_token(t_type type, const char *value)
+void	set_quote(char q)
 {
-	t_token	*new;
+	char	*fq;
 
-	new = ft_calloc(1, sizeof (*new));
-	if (!new)
-		return (NULL);
-	new->type = type;
-	new->value = value;
-	return (new);
+	fq = NULL;
+	*fq = get_quote();
+	*fq = q;
 }

--- a/src/lexer/token_new_del.c
+++ b/src/lexer/token_new_del.c
@@ -1,0 +1,35 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   new_token.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/01 23:04:44 by lrocigno          #+#    #+#             */
+/*   Updated: 2022/02/01 23:11:45 by lrocigno         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <lexer/lexer.h>
+
+void	del_token(t_token *del)
+{
+	char	*value;
+
+	value = (char *)del->value;
+	safe_free((void **)&value);
+	del->type = INVALID;
+	safe_free((void **)&del);
+}
+
+t_token	*new_token(t_type type, const char *value)
+{
+	t_token	*new;
+
+	new = ft_calloc(1, sizeof (*new));
+	if (!new)
+		return (NULL);
+	new->type = type;
+	new->value = value;
+	return (new);
+}

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -1,0 +1,80 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   tokenizer.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/02/01 13:49:35 by lrocigno          #+#    #+#             */
+/*   Updated: 2022/02/02 01:24:11 by lrocigno         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <lexer/lexer.h>
+
+void	discard_tokens(t_token **tokens)
+{
+	size_t	i;
+
+	i = 0;
+	while (tokens[i]->type != INVALID)
+	{
+		del_token(tokens[i]);
+		++i;
+	}
+	del_token(tokens[i]);
+	safe_free((void **)&tokens); // O compilador está dizendo que a declaração é inválida.
+}
+
+/**
+ * Count the amount of tokens to create a array of them.
+ */
+
+static size_t	cnt_tokens(char *input)
+{
+	size_t	cnt;
+	size_t	i;
+	int		quotes;
+	int		is_word;
+
+	cnt = 0;
+	i = 0;
+	quotes = 0;
+	is_word = 0;
+	while (input[i] != '\0' && input[i] != '#')
+	{
+		if (ft_isalnum(input[i]) && !is_word)
+		{
+			++cnt;
+			is_word = 1;
+		}
+		else if (lex_isspace(input[i]) && quotes % 2 == 0)
+			is_word = 0;
+		else if (input[i] == '\"' || input[i] == '\'')
+			++quotes;
+		++i;
+	}
+	return (cnt);
+}
+
+t_token	**tokenizer(char *input)
+{
+	size_t	n_tokens;
+	size_t	i;
+	t_type	type;
+	char	*value;
+	t_token	**tokens;
+
+	n_tokens = cnt_tokens(input);
+	i = 0;
+	tokens = ft_calloc(n_tokens + 1, sizeof (*tokens));
+	while (i < n_tokens)
+	{
+		type = get_type(i, input);
+		value = get_value(type, input);
+		tokens[i] = new_token(type, value);
+		++i;
+	}
+	tokens[i] = new_token(INVALID, NULL);
+	return (tokens);
+}

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -57,7 +57,7 @@ t_token	**tokenizer(char *input)
 	while (i < n_tokens)
 	{
 		type = get_type(i, input);
-		if (type != INVALID && type != COMMENT)
+		if (type != INVALID)
 			value = get_value(type, input);
 		else
 			value = NULL;

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -6,25 +6,11 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/01 13:49:35 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 01:24:11 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 14:49:19 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <lexer/lexer.h>
-
-void	discard_tokens(t_token **tokens)
-{
-	size_t	i;
-
-	i = 0;
-	while (tokens[i]->type != INVALID)
-	{
-		del_token(tokens[i]);
-		++i;
-	}
-	del_token(tokens[i]);
-	safe_free((void **)&tokens); // O compilador está dizendo que a declaração é inválida.
-}
 
 /**
  * Count the amount of tokens to create a array of them.
@@ -71,10 +57,29 @@ t_token	**tokenizer(char *input)
 	while (i < n_tokens)
 	{
 		type = get_type(i, input);
-		value = get_value(type, input);
+		if (type != INVALID && type != COMMENT)
+			value = get_value(type, input);
+		else
+			value = NULL;
 		tokens[i] = new_token(type, value);
+		input += ft_strlen(value);
 		++i;
 	}
 	tokens[i] = new_token(INVALID, NULL);
 	return (tokens);
+}
+
+void	discard_tokens(t_token **tokens)
+{
+	size_t	i;
+
+	i = 0;
+	while (tokens[i]->type != INVALID)
+	{
+		del_token(tokens[i]);
+		++i;
+	}
+	del_token(tokens[i]);
+	free(tokens);
+	tokens = NULL;
 }

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -51,9 +51,9 @@ t_token	**tokenizer(char *input)
 	char	*value;
 	t_token	**tokens;
 
-	n_tokens = cnt_tokens(input);
 	i = 0;
-	tokens = ft_calloc(n_tokens + 1, sizeof (*tokens));
+	n_tokens = cnt_tokens(input);
+	tokens = ft_calloc(n_tokens + 1, sizeof (t_token *));
 	while (i < n_tokens)
 	{
 		type = get_type(i, input);

--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -6,7 +6,7 @@
 /*   By: lrocigno <lrocigno@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/01 13:49:35 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 14:49:19 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/03 07:16:44 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,7 @@ t_token	**tokenizer(char *input)
 		input += ft_strlen(value);
 		++i;
 	}
-	tokens[i] = new_token(INVALID, NULL);
+	tokens[i] = NULL;
 	return (tokens);
 }
 
@@ -74,7 +74,7 @@ void	discard_tokens(t_token **tokens)
 	size_t	i;
 
 	i = 0;
-	while (tokens[i]->type != INVALID)
+	while (tokens != NULL)
 	{
 		del_token(tokens[i]);
 		++i;

--- a/src/minishell.h
+++ b/src/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/19 12:44:26 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/01/31 10:48:40 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/02/02 01:16:30 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,13 +19,13 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
-# include <libft.h>
 # include <ft_printf.h>
 # include <stdio.h>
 
 /**
- * Carries the environment variables separatelly
+ * Hold the environment variables separatelly
  */
+
 typedef struct s_env
 {
 	const char		*name;
@@ -34,8 +34,9 @@ typedef struct s_env
 }	t_env;
 
 /**
- * Carries general information of the shell
+ * Hold general information of the shell
  */
+
 typedef struct s_shell
 {
 	t_env	*env;
@@ -47,14 +48,22 @@ typedef struct s_shell
 }	t_shell;
 
 /**
- * Initializes the shell
- * @param sh: the shell
+ * Receive the user input, parse, execute (if it is a valid command) and stores
+ * in the history (when it isn't a empty line).
+ * @param input: empty string, sh: the shell
  */
 
 void	interface(char *input, t_shell *sh);
 
 /**
- * Finilizes the shell
+ * Tokenize the input.
+ * @param input: a string received from the user
+ */
+
+void	tokenizer(char *input);
+
+/**
+ * Finalizes the shell
  * @param sh: the shell
  */
 

--- a/src/minishell.h
+++ b/src/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/19 12:44:26 by lrocigno          #+#    #+#             */
-/*   Updated: 2022/02/02 01:16:30 by lrocigno         ###   ########.fr       */
+/*   Updated: 2022/02/02 15:06:46 by lrocigno         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@
 
 # include <ft_printf.h>
 # include <stdio.h>
+# include <lexer/lexer.h>
 
 /**
  * Hold the environment variables separatelly
@@ -54,13 +55,6 @@ typedef struct s_shell
  */
 
 void	interface(char *input, t_shell *sh);
-
-/**
- * Tokenize the input.
- * @param input: a string received from the user
- */
-
-void	tokenizer(char *input);
 
 /**
  * Finalizes the shell


### PR DESCRIPTION
Os bugs de memória foram corrigidos e agora há uma função "quote" que seta um tipo de aspa quando necessário (informando \" ou \'), pega a aspa definida usando a flag 'g' (ou qualquer outro char que não seja nenhum tipo de aspa e nem 'd') e limpa o aspa usando a flag 'd'.

Essa última parte ocorre porquê a aspa é armazenada num static char, não há alocação de memória para esse char estático, porém a limpeza da aspa pode ser necessária.