### PR TITLE
Implementar o Parseamento da AST a partir dos tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/17 10:49:54 by lrocigno          #+#    #+#              #
-#    Updated: 2022/03/20 13:30:23 by vgoncalv         ###   ########.fr        #
+#    Updated: 2022/03/22 11:17:25 by vgoncalv         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -30,7 +30,7 @@ SRC :=	minishell.c get_pwd.c prompt.c interactive.c \
 		free.c error.c parse.c get_env.c set_env.c \
 		character_checkers.c token.c word.c operator.c \
 		tokenizer.c heredocs.c node.c parser_error.c \
-		parse_command.c parser.c
+		parse_command.c parse_operator.c parser.c
 
 OBJ_PATH = ./build
 OBJ := $(addprefix $(OBJ_PATH)/,$(SRC:%.c=%.o))

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: vgoncalv <vgoncalv@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/01/17 10:49:54 by lrocigno          #+#    #+#              #
-#    Updated: 2022/03/17 15:33:09 by vgoncalv         ###   ########.fr        #
+#    Updated: 2022/03/20 13:30:23 by vgoncalv         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -25,11 +25,12 @@ LIBS = $(LIBFT_FLAGS) -lreadline
 INCLUDES = -I ./lib/libft/includes \
 		   -I ./src
 
-vpath %.c src src/env src/prompt src/lexer
+vpath %.c src src/env src/prompt src/lexer src/parser
 SRC :=	minishell.c get_pwd.c prompt.c interactive.c \
 		free.c error.c parse.c get_env.c set_env.c \
 		character_checkers.c token.c word.c operator.c \
-		tokenizer.c heredocs.c
+		tokenizer.c heredocs.c node.c parser_error.c \
+		parse_command.c parser.c
 
 OBJ_PATH = ./build
 OBJ := $(addprefix $(OBJ_PATH)/,$(SRC:%.c=%.o))

--- a/src/interactive.c
+++ b/src/interactive.c
@@ -6,14 +6,14 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/27 20:12:16 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/17 19:35:14 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/20 14:02:19 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 #include <prompt/prompt.h>
 #include <lexer/lexer.h>
-#include <unistd.h>
+#include <parser/parser.h>
 
 /**
  * @brief Stores the input on the history, then validates and tokenize it.
@@ -23,15 +23,17 @@
  */
 static uint8_t	validate(char **input)
 {
-	t_token	*token;
+	t_ast		*ast;
+	t_token		*token;
 
-	if (*input != NULL && ft_strlen(*input) == 0)
-		return (0);
 	if (*input == NULL)
 		return (1);
+	if (ft_strlen(*input) == 0)
+		return (0);
 	add_history(*input);
-	token = NULL;
 	token = tokenize(*input);
+	ast = build_ast(token);
+	clear_ast(ast);
 	clear_tokens(token);
 	return (0);
 }

--- a/src/parser/node.c
+++ b/src/parser/node.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/19 13:47:34 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/20 14:08:45 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/22 11:19:24 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@ t_ast	*new_node(t_ast_type type)
 {
 	t_ast		*node;
 
+	if (type == AST_COUNT)
+		return (NULL);
 	node = ft_calloc(1, sizeof(t_ast));
 	if (node == NULL)
 		return (NULL);

--- a/src/parser/node.c
+++ b/src/parser/node.c
@@ -1,0 +1,52 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   node.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/03/19 13:47:34 by vgoncalv          #+#    #+#             */
+/*   Updated: 2022/03/20 13:56:18 by vgoncalv         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <parser/parser.h>
+
+/**
+ * @brief Creates a new node for the AST
+ *
+ * @param type: The type of the node
+ * @return: The created node
+ */
+t_ast	*new_node(t_ast_type type)
+{
+	t_ast		*node;
+
+	node = ft_calloc(1, sizeof(t_ast));
+	if (node == NULL)
+		return (NULL);
+	node->type = type;
+	if (type == BUILTIN || type == COMMAND)
+	{
+		node->internal.command = ft_calloc(1, sizeof(t_command));
+		if (node->internal.command == NULL)
+			safe_free((void **)&node);
+		return (node);
+	}
+	node->internal.child = ft_calloc(1, sizeof(t_child));
+	if (node->internal.child == NULL)
+		safe_free((void **)&node);
+	return (node);
+}
+
+void	clear_node(t_ast	*node)
+{
+	if (node->type == COMMAND)
+	{
+		safe_free((void **)&(node->internal.command->args));
+		safe_free((void **)&(node->internal.command));
+	}
+	else
+		safe_free((void **)&(node->internal.child));
+	safe_free((void **)&node);
+}

--- a/src/parser/node.c
+++ b/src/parser/node.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/19 13:47:34 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/20 13:56:18 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/20 14:08:45 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,8 @@ t_ast	*new_node(t_ast_type type)
 
 void	clear_node(t_ast	*node)
 {
+	if (node == NULL)
+		return ;
 	if (node->type == COMMAND)
 	{
 		safe_free((void **)&(node->internal.command->args));

--- a/src/parser/parse_command.c
+++ b/src/parser/parse_command.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/20 11:34:20 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/21 08:42:06 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/22 11:47:33 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ t_ast	*parse_command(t_token **token)
 	if (command == NULL)
 		return (NULL);
 	argc = argslen(*token);
-	command->internal.command->args = ft_calloc(1, (argc + 1) * sizeof(char *));
+	command->internal.command->args = ft_calloc(argc + 1, sizeof(char *));
 	if (command->internal.command->args == NULL)
 		return (parser_error(command, NULL));
 	count = 0;

--- a/src/parser/parse_command.c
+++ b/src/parser/parse_command.c
@@ -1,0 +1,69 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_command.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/03/20 11:34:20 by vgoncalv          #+#    #+#             */
+/*   Updated: 2022/03/20 13:58:27 by vgoncalv         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <parser/parser.h>
+
+/**
+ * @brief Gets the number of arguments in a command
+ *
+ * @see t_command
+ * @param token: the starting token
+ */
+static	size_t	argslen(t_token *token)
+{
+	size_t	len;
+
+	len = 0;
+	while (token != NULL)
+	{
+		if (token->type != T_WORD)
+			break ;
+		len++;
+		token = token->next;
+	}
+	return (len - 1);
+}
+
+/**
+ * @brief Parses a command and updates the AST accordingly
+ *
+ * @param token: the starting token to be parsed
+ * @return: the AST root node
+ */
+t_ast	*parse_command(t_token **token)
+{
+	size_t		argc;
+	size_t		count;
+	t_ast		*command;
+
+	command = new_node(COMMAND);
+	if (command == NULL)
+		return (NULL);
+	argc = argslen(*token);
+	command->internal.command->args = ft_calloc(1, (argc + 1) * sizeof(char *));
+	if (command->internal.command->args == NULL)
+		return (parser_error(command, NULL));
+	count = 0;
+	while (*token != NULL)
+	{
+		if ((*token)->type != T_WORD)
+			break ;
+		if (command->internal.command->cmd == NULL)
+			command->internal.command->cmd = (*token)->value;
+		else if (count < argc)
+			command->internal.command->args[count++] = (*token)->value;
+		else
+			return (parser_error(command, *token));
+		*token = (*token)->next;
+	}
+	return (command);
+}

--- a/src/parser/parse_command.c
+++ b/src/parser/parse_command.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/20 11:34:20 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/20 13:58:27 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/21 08:42:06 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
  * @brief Gets the number of arguments in a command
  *
  * @see t_command
- * @param token: the starting token
+ * @param token: The starting token
  */
 static	size_t	argslen(t_token *token)
 {
@@ -34,10 +34,10 @@ static	size_t	argslen(t_token *token)
 }
 
 /**
- * @brief Parses a command and updates the AST accordingly
+ * @brief Parses a command
  *
- * @param token: the starting token to be parsed
- * @return: the AST root node
+ * @param token: The starting token to be parsed
+ * @return: The parsed command node
  */
 t_ast	*parse_command(t_token **token)
 {

--- a/src/parser/parse_operator.c
+++ b/src/parser/parse_operator.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/21 08:40:28 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/21 08:46:33 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/24 11:59:30 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,10 @@ static t_ast_type	get_type(t_token *token)
 {
 	if ((ft_strcmp(token->value, L_PIPE) == 0))
 		return (PIPE);
+	if ((ft_strcmp(token->value, L_IF_OR) == 0))
+		return (IF_OR);
+	if ((ft_strcmp(token->value, L_IF_AND) == 0))
+		return (IF_AND);
 	return (AST_COUNT);
 }
 

--- a/src/parser/parse_operator.c
+++ b/src/parser/parse_operator.c
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_operator.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/03/21 08:40:28 by vgoncalv          #+#    #+#             */
+/*   Updated: 2022/03/21 08:46:33 by vgoncalv         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <parser/parser.h>
+
+static t_ast_type	get_type(t_token *token)
+{
+	if ((ft_strcmp(token->value, L_PIPE) == 0))
+		return (PIPE);
+	return (AST_COUNT);
+}
+
+/**
+ * @brief Parses an operator token
+ *
+ * @param token: The starting token
+ * @return: the operator node
+ */
+t_ast	*parse_operator(t_token **token)
+{
+	t_ast		*node;
+	t_ast_type	type;
+
+	type = get_type(*token);
+	node = new_node(type);
+	if (node == NULL)
+		return (parser_error(NULL, *token));
+	*token = (*token)->next;
+	return (node);
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,37 +6,30 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/20 13:26:57 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/22 11:32:01 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/28 16:18:36 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <parser/parser.h>
 
-static t_ast	*insert_node(t_ast *ast, t_ast *node, t_token *token)
+static t_ast	*insert_node(t_ast *ast, t_ast *node)
 {
-	if (node == NULL)
-		return (parser_error(node, token));
 	if (node->type == COMMAND || node->type == BUILTIN)
 	{
 		if (ast == NULL)
 			return (node);
-		if (ast->type == COMMAND)
+		if (ast->type == COMMAND || ast->type == BUILTIN)
 		{
 			clear_ast(ast);
-			return (parser_error(node, token));
+			return (NULL);
 		}
 		ast->internal.child->right = node;
 		return (ast);
 	}
 	if (ast == NULL)
-		return (parser_error(node, token));
-	if (node->type == PIPE)
-	{
-		node->internal.child->left = ast;
-		return (node);
-	}
-	clear_node(node);
-	return (NULL);
+		return (NULL);
+	node->internal.child->left = ast;
+	return (node);
 }
 
 /**
@@ -47,20 +40,27 @@ static t_ast	*insert_node(t_ast *ast, t_ast *node, t_token *token)
  */
 t_ast	*build_ast(t_token *token)
 {
-	t_ast	*ast;
-	t_ast	*node;
+	t_ast		*ast;
+	t_ast		*node;
+	t_token		*ref;
 
 	ast = NULL;
 	node = NULL;
 	while (token != NULL)
 	{
+		ref = token;
 		if (token->type == T_WORD)
 			node = parse_command(&token);
 		else
 			node = parse_operator(&token);
-		ast = insert_node(ast, node, token);
-		if (ast == NULL)
+		if (node == NULL)
+		{
+			clear_ast(ast);
 			return (NULL);
+		}
+		ast = insert_node(ast, node);
+		if (ast == NULL)
+			return (parser_error(node, ref));
 	}
 	return (ast);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,0 +1,56 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/03/20 13:26:57 by vgoncalv          #+#    #+#             */
+/*   Updated: 2022/03/20 13:36:38 by vgoncalv         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <parser/parser.h>
+
+/**
+ * @brief Builds the AST
+ *
+ * @param token: The starting token
+ * @return: The built AST
+ */
+t_ast	*build_ast(t_token *token)
+{
+	t_ast	*ast;
+
+	ast = NULL;
+	while (token != NULL)
+	{
+		if (token->type == T_WORD)
+			ast = parse_command(&token);
+		else
+			error();
+	}
+	return (ast);
+}
+
+/**
+ * @brief Clears the AST
+ *
+ * @param ast: The AST to be cleared
+ */
+void	clear_ast(t_ast *ast)
+{
+	t_ast	*left;
+	t_ast	*right;
+
+	if (ast->type == COMMAND)
+	{
+		clear_node(ast);
+		return ;
+	}
+	left = ast->internal.child->left;
+	right = ast->internal.child->right;
+	clear_ast(left);
+	clear_ast(right);
+	clear_node(ast);
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/20 13:26:57 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/20 13:36:38 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/20 14:08:34 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@ t_ast	*build_ast(t_token *token)
 {
 	t_ast	*ast;
 
+	if (token == NULL)
+		return (NULL);
 	ast = NULL;
 	while (token != NULL)
 	{
@@ -43,6 +45,8 @@ void	clear_ast(t_ast *ast)
 	t_ast	*left;
 	t_ast	*right;
 
+	if (ast == NULL)
+		return ;
 	if (ast->type == COMMAND)
 	{
 		clear_node(ast);

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -6,7 +6,7 @@
 /*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/19 13:37:02 by vgoncalv          #+#    #+#             */
-/*   Updated: 2022/03/20 14:01:30 by vgoncalv         ###   ########.fr       */
+/*   Updated: 2022/03/21 08:46:39 by vgoncalv         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,8 @@ void	clear_node(t_ast	*node);
 t_ast	*parser_error(t_ast *node, t_token *token);
 
 t_ast	*parse_command(t_token **token);
+
+t_ast	*parse_operator(t_token **token);
 
 t_ast	*build_ast(t_token *token);
 

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser.h                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/03/19 13:37:02 by vgoncalv          #+#    #+#             */
+/*   Updated: 2022/03/20 14:01:30 by vgoncalv         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef PARSER_H
+# define PARSER_H
+
+# include <lexer/lexer.h>
+
+# define L_PIPE "|"
+# define L_IF_OR "||"
+# define L_IF_AND "&&"
+
+typedef struct s_command
+{
+	const char	*cmd;
+	const char	**args;
+}	t_command;
+
+typedef struct s_child
+{
+	struct s_ast	*left;
+	struct s_ast	*right;
+}	t_child;
+
+typedef enum e_ast_type
+{
+	BUILTIN,
+	COMMAND,
+	PIPE,
+	IF_OR,
+	IF_AND,
+	AST_COUNT,
+}	t_ast_type;
+
+typedef struct s_ast
+{
+	t_ast_type	type;
+	union u_internal {
+		t_child		*child;
+		t_command	*command;
+	}			internal;
+}	t_ast;
+
+t_ast	*new_node(t_ast_type type);
+
+void	clear_node(t_ast	*node);
+
+t_ast	*parser_error(t_ast *node, t_token *token);
+
+t_ast	*parse_command(t_token **token);
+
+t_ast	*build_ast(t_token *token);
+
+void	clear_ast(t_ast *ast);
+
+#endif

--- a/src/parser/parser_error.c
+++ b/src/parser/parser_error.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parser_error.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vgoncalv <vgoncalv@student.42sp.o...>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/03/20 12:23:46 by vgoncalv          #+#    #+#             */
+/*   Updated: 2022/03/20 12:30:55 by vgoncalv         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <parser/parser.h>
+
+t_ast	*parser_error(t_ast *node, t_token *token)
+{
+	char	*fmt;
+
+	if (token != NULL)
+		fmt = "minishell: parsing error near '%s'\n";
+	else
+		fmt = "minishell: internal parsing error\n";
+	ft_dprintf(STDERR_FILENO, fmt, token->value);
+	if (node != NULL)
+		clear_node(node);
+	return (NULL);
+}


### PR DESCRIPTION
Este PR é um Draft.

Roadmap
---
- [X] Implementar parseamento simples apenas para comandos(sem redirects)
- [x] Implementar parseamento para `PIPE`
- [x] Parseamento de `IF_OR`, `IF_AND`
- [ ] Implementar parsemando de redirects nos comandos

Importante: os valores para `cmd` e `args`, atributos do `t_command`, são apenas referências ao valor dos tokens. Por isso o `clear_ast` vem antes do `clear_tokens`.